### PR TITLE
text highlight directive

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,1 @@
-<div>
-  <input type="text" autofocus placeholder="Auto foucs input" />
-</div>
+<p appHighlight>This is highlighted text</p>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,11 +3,13 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppComponent } from './app.component';
 import { AutoFocusDirective } from './auto-focus.directive';
+import { HighlightDirective } from './highlight.directive';
 
 @NgModule({
   declarations: [
     AppComponent,
-    AutoFocusDirective
+    AutoFocusDirective,
+    HighlightDirective
   ],
   imports: [
     BrowserModule

--- a/src/app/highlight.directive.spec.ts
+++ b/src/app/highlight.directive.spec.ts
@@ -1,0 +1,8 @@
+import { HighlightDirective } from './highlight.directive';
+
+describe('HighlightDirective', () => {
+  it('should create an instance', () => {
+    const directive = new HighlightDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/highlight.directive.ts
+++ b/src/app/highlight.directive.ts
@@ -1,0 +1,20 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[appHighlight]',
+})
+export class HighlightDirective {
+  constructor(private el: ElementRef) {}
+
+  @HostListener('mouseenter') onMouseEnter() {
+    this.Highlight('yellow');
+  }
+
+  @HostListener('mouseleave') onMouseLeave() {
+    this.Highlight(null);
+  }
+
+  private Highlight(color: any) {
+    this.el.nativeElement.style.backgroundColor = color;
+  }
+}


### PR DESCRIPTION
A directive to highlight text or to validate form inputs.

**@HostListener:**

- The @HostListener decorator is used to listen to events on the host element (the element to which the directive is applied) and execute a method in response to those events.

- It takes two parameters: the event name and optionally, an array of arguments to pass to the event handler method.